### PR TITLE
Update composer.json again, fix errors related to missing config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Cài đặt Laravel Number To Words thông qua [Composer](https://getcomposer.or
 composer require phpviet/laravel-number-to-words
 ```
 
+Publish file cấu hình thông qua câu lệnh:
+
+```php
+php artisan vendor:publish --provider="PHPViet\Laravel\NumberToWords\ServiceProvider" --tag="config"
+```
+
 ## Cách sử dụng
 
 ### Các tính năng của extension:
@@ -99,13 +105,7 @@ n2c(9492.15, ['đô', 'xen']);
 
 > Nếu như bạn cảm thấy cách đọc ở trên ổn rồi thì hãy bỏ qua bước này.
 
-Đầu tiên để thay đổi cách đọc số bạn cần phải publish file cấu hình thông qua câu lệnh:
-
-```php
-php artisan vendor:publish --provider="PHPViet\Laravel\NumberToWords\ServiceProvider" --tag="config"
-```
-
-Sau khi publish xong ta sẽ có được file config `config/n2w.php` như sau:
+Đầu tiên, bạn mở file config `config/n2w.php` như sau:
 
 ```php
 return [

--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ Cài đặt Laravel Number To Words thông qua [Composer](https://getcomposer.or
 composer require phpviet/laravel-number-to-words
 ```
 
-Publish file cấu hình thông qua câu lệnh:
-
-```php
-php artisan vendor:publish --provider="PHPViet\Laravel\NumberToWords\ServiceProvider" --tag="config"
-```
-
 ## Cách sử dụng
 
 ### Các tính năng của extension:
@@ -105,7 +99,13 @@ n2c(9492.15, ['đô', 'xen']);
 
 > Nếu như bạn cảm thấy cách đọc ở trên ổn rồi thì hãy bỏ qua bước này.
 
-Đầu tiên, bạn mở file config `config/n2w.php` như sau:
+Đầu tiên để thay đổi cách đọc số bạn cần phải publish file cấu hình thông qua câu lệnh:
+
+```php
+php artisan vendor:publish --provider="PHPViet\Laravel\NumberToWords\ServiceProvider" --tag="config"
+```
+
+Sau khi publish xong ta sẽ có được file config `config/n2w.php` như sau:
 
 ```php
 return [
@@ -207,6 +207,6 @@ N2W::toWords(15);
 
 ## Dành cho nhà phát triển
 
-Nếu như bạn cảm thấy extension còn thiếu sót hoặc sai sót và bạn muốn đóng góp để phát triển chung, 
-chúng tôi rất hoan nghênh! Hãy tạo các `issue` để đóng góp ý tưởng cho phiên bản kế tiếp 
+Nếu như bạn cảm thấy extension còn thiếu sót hoặc sai sót và bạn muốn đóng góp để phát triển chung,
+chúng tôi rất hoan nghênh! Hãy tạo các `issue` để đóng góp ý tưởng cho phiên bản kế tiếp
 hoặc tạo `PR` để đóng góp. Cảm ơn!

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "phpviet/number-to-words": "^1.2",
-        "illuminate/support": ">6"
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.17"
+        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "phpviet/number-to-words": "^1.2",
-        "illuminate/support": "^8.39"
+        "illuminate/support": ">6"
     },
     "require-dev": {
         "orchestra/testbench": "^6.17"

--- a/src/N2WFacade.php
+++ b/src/N2WFacade.php
@@ -11,7 +11,6 @@ namespace PHPViet\Laravel\NumberToWords;
 use Illuminate\Support\Facades\Facade;
 use InvalidArgumentException;
 use PHPViet\NumberToWords\DictionaryInterface;
-use LogicException;
 
 /**
  * @method static string toWords($number)
@@ -34,8 +33,6 @@ class N2WFacade extends Facade
      */
     protected static function getFacadeAccessor(): Transformer
     {
-        static::checkConfigIsPublished();
-
         $dictionary = static::$dictionary ?? static::getDefaultDictionary();
         $dictionary = static::makeDictionary($dictionary);
 
@@ -65,18 +62,5 @@ class N2WFacade extends Facade
         }
 
         return app()->make($dictionaryClass);
-    }
-
-    /**
-     * Throw an Exception when the config is not exist
-     * Please run: php artisan vendor:publish --provider="PHPViet\Laravel\NumberToWords\ServiceProvider" --tag="config"
-     *
-     * @throws LogicException
-     */
-    protected static function checkConfigIsPublished()
-    {
-        if (!config()->has('n2w')) {
-            throw new LogicException("The config file is not found. You must publish the config before using it!");
-        }
     }
 }

--- a/src/N2WFacade.php
+++ b/src/N2WFacade.php
@@ -11,6 +11,7 @@ namespace PHPViet\Laravel\NumberToWords;
 use Illuminate\Support\Facades\Facade;
 use InvalidArgumentException;
 use PHPViet\NumberToWords\DictionaryInterface;
+use LogicException;
 
 /**
  * @method static string toWords($number)
@@ -33,6 +34,8 @@ class N2WFacade extends Facade
      */
     protected static function getFacadeAccessor(): Transformer
     {
+        static::checkConfigIsPublished();
+
         $dictionary = static::$dictionary ?? static::getDefaultDictionary();
         $dictionary = static::makeDictionary($dictionary);
 
@@ -62,5 +65,18 @@ class N2WFacade extends Facade
         }
 
         return app()->make($dictionaryClass);
+    }
+
+    /**
+     * Throw an Exception when the config is not exist
+     * Please run: php artisan vendor:publish --provider="PHPViet\Laravel\NumberToWords\ServiceProvider" --tag="config"
+     *
+     * @throws LogicException
+     */
+    protected static function checkConfigIsPublished()
+    {
+        if (!config()->has('n2w')) {
+            throw new LogicException("The config file is not found. You must publish the config before using it!");
+        }
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -8,7 +8,6 @@
 
 namespace PHPViet\Laravel\NumberToWords;
 
-use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use PHPViet\NumberToWords\Dictionary;
 use PHPViet\NumberToWords\DictionaryInterface;
@@ -18,12 +17,8 @@ use PHPViet\NumberToWords\SouthDictionary;
  * @author Vuong Minh <vuongxuongminh@gmail.com>
  * @since 1.0.0
  */
-class ServiceProvider extends BaseServiceProvider implements DeferrableProvider
+class ServiceProvider extends BaseServiceProvider
 {
-    public $bindings = [
-        'n2w' => Transformer::class,
-    ];
-
     public $singletons = [
         Dictionary::class => Dictionary::class,
         DictionaryInterface::class => Dictionary::class,
@@ -40,10 +35,5 @@ class ServiceProvider extends BaseServiceProvider implements DeferrableProvider
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/n2w.php', 'n2w');
-    }
-
-    public function provides(): array
-    {
-        return ['n2w'];
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -19,6 +19,10 @@ use PHPViet\NumberToWords\SouthDictionary;
  */
 class ServiceProvider extends BaseServiceProvider
 {
+    public $bindings = [
+        'n2w' => Transformer::class,
+    ];
+
     public $singletons = [
         Dictionary::class => Dictionary::class,
         DictionaryInterface::class => Dictionary::class,


### PR DESCRIPTION
In previous PR I required latest version of laravel in the composer.json file `"illuminate/support": "^8.39"`, which makes the library can't install on lower versions, such as 6, 7 and 8. I fixed it.

After the package is installed, it needs config file to work. So I updated README to prompt to publish the configuration after install. And throw an exception if a config file is not found.